### PR TITLE
Fix deadline timezone: local time interpreted as UTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4.3] - 2026-03-27
+
+### Fixed
+- Deadline timezone bug: `input_datetime` values (user's local time) were interpreted as UTC, causing charge windows to extend past the configured deadline
+
 ## [0.4.2] - 2026-03-21
 
 ### Changed

--- a/custom_components/ev_charge_planner/manifest.json
+++ b/custom_components/ev_charge_planner/manifest.json
@@ -5,5 +5,5 @@
     "config_flow": true,
     "after_dependencies": ["nordpool"],
     "iot_class": "calculated",
-    "version": "0.4.2"
+    "version": "0.4.3"
 }

--- a/custom_components/ev_charge_planner/service/hub.py
+++ b/custom_components/ev_charge_planner/service/hub.py
@@ -79,7 +79,7 @@ class Hub:
         self._prices: list[PriceSlot] = []
         try:
             self._local_tz: ZoneInfo = ZoneInfo(hass.config.time_zone) if hass else ZoneInfo("UTC")
-        except (KeyError, TypeError):
+        except (KeyError, TypeError):  # KeyError covers ZoneInfoNotFoundError
             _LOGGER.warning("Invalid time_zone in HA config, falling back to UTC")
             self._local_tz = ZoneInfo("UTC")
 
@@ -327,7 +327,7 @@ class Hub:
                 return deadline
             else:
                 parsed = datetime.fromisoformat(time_str)
-                if parsed.tzinfo is None:
+                if parsed.tzinfo is None and now.tzinfo is not None:
                     parsed = parsed.replace(tzinfo=self._local_tz)
                 return parsed
         except (ValueError, IndexError):

--- a/custom_components/ev_charge_planner/service/hub.py
+++ b/custom_components/ev_charge_planner/service/hub.py
@@ -77,9 +77,7 @@ class Hub:
         self._freeze_state: dict[str, tuple[float, datetime]] = {}
 
         self._prices: list[PriceSlot] = []
-        self._local_tz: ZoneInfo = (
-            ZoneInfo(hass.config.time_zone) if hass else ZoneInfo("UTC")
-        )
+        self._local_tz: ZoneInfo = ZoneInfo(hass.config.time_zone) if hass else ZoneInfo("UTC")
 
         # Determine price sensor (all vehicles share the same one)
         if spotprice is not None:

--- a/custom_components/ev_charge_planner/service/hub.py
+++ b/custom_components/ev_charge_planner/service/hub.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import time
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
 from homeassistant.core import Event, HomeAssistant, callback

--- a/custom_components/ev_charge_planner/service/hub.py
+++ b/custom_components/ev_charge_planner/service/hub.py
@@ -77,7 +77,11 @@ class Hub:
         self._freeze_state: dict[str, tuple[float, datetime]] = {}
 
         self._prices: list[PriceSlot] = []
-        self._local_tz: ZoneInfo = ZoneInfo(hass.config.time_zone) if hass else ZoneInfo("UTC")
+        try:
+            self._local_tz: ZoneInfo = ZoneInfo(hass.config.time_zone) if hass else ZoneInfo("UTC")
+        except (KeyError, TypeError):
+            _LOGGER.warning("Invalid time_zone in HA config, falling back to UTC")
+            self._local_tz = ZoneInfo("UTC")
 
         # Determine price sensor (all vehicles share the same one)
         if spotprice is not None:
@@ -323,8 +327,8 @@ class Hub:
                 return deadline
             else:
                 parsed = datetime.fromisoformat(time_str)
-                if parsed.tzinfo is None and now.tzinfo is not None:
-                    parsed = parsed.replace(tzinfo=now.tzinfo)
+                if parsed.tzinfo is None:
+                    parsed = parsed.replace(tzinfo=self._local_tz)
                 return parsed
         except (ValueError, IndexError):
             return now + timedelta(hours=8)

--- a/custom_components/ev_charge_planner/service/hub.py
+++ b/custom_components/ev_charge_planner/service/hub.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import logging
 import time
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
 
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers.event import (
@@ -76,6 +77,9 @@ class Hub:
         self._freeze_state: dict[str, tuple[float, datetime]] = {}
 
         self._prices: list[PriceSlot] = []
+        self._local_tz: ZoneInfo = (
+            ZoneInfo(hass.config.time_zone) if hass else ZoneInfo("UTC")
+        )
 
         # Determine price sensor (all vehicles share the same one)
         if spotprice is not None:
@@ -313,8 +317,10 @@ class Hub:
             if len(time_str) <= 8:  # "HH:MM" or "HH:MM:SS"
                 parts = time_str.split(":")
                 hour, minute = int(parts[0]), int(parts[1])
-                deadline = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
-                if deadline <= now:
+                # input_datetime values are in the user's local timezone
+                local_now = now.astimezone(self._local_tz) if now.tzinfo else now
+                deadline = local_now.replace(hour=hour, minute=minute, second=0, microsecond=0)
+                if deadline <= local_now:
                     deadline += timedelta(days=1)
                 return deadline
             else:

--- a/tests/test_hub_freeze.py
+++ b/tests/test_hub_freeze.py
@@ -290,6 +290,21 @@ async def test_deadline_same_day_not_passed_local():
 
 
 @pytest.mark.asyncio
+async def test_deadline_datetime_naive_gets_local_tz():
+    """Naive date+time string should get local tz, not UTC."""
+    hub = Hub(None, [make_vehicle_config()], test=True)
+    hub._local_tz = ZoneInfo("Europe/Stockholm")
+    now = datetime(2024, 1, 15, 22, 0, tzinfo=UTC)
+    reader = FakeStateReader({"input_datetime.deadline": "2024-01-16 06:00:00"})
+    hub._state_reader = reader
+
+    deadline = hub._get_deadline("input_datetime.deadline", now)
+    utc_deadline = deadline.astimezone(UTC)
+    assert utc_deadline.hour == 5, "Naive 06:00 should be treated as CET = 05:00 UTC"
+    assert utc_deadline.day == 16
+
+
+@pytest.mark.asyncio
 async def test_vat_percent_to_multiplier():
     """VAT percent is converted to multiplier in Vehicle."""
     config = make_vehicle_config()

--- a/tests/test_hub_freeze.py
+++ b/tests/test_hub_freeze.py
@@ -2,6 +2,7 @@
 
 import time
 from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -195,6 +196,23 @@ async def test_deadline_works_with_aware_now():
     deadline = hub._get_deadline("input_datetime.deadline", now)
     assert deadline.tzinfo is not None, "Deadline must be tz-aware when now is tz-aware"
     assert deadline.day == 16
+
+
+@pytest.mark.asyncio
+async def test_deadline_local_timezone():
+    """Deadline 06:00 local (CET) must not become 06:00 UTC."""
+    hub = Hub(None, [make_vehicle_config()], test=True)
+    hub._local_tz = ZoneInfo("Europe/Stockholm")
+    # now = 2024-01-15 22:00 UTC = 2024-01-15 23:00 CET
+    now = datetime(2024, 1, 15, 22, 0, tzinfo=UTC)
+    reader = FakeStateReader({"input_datetime.deadline": "06:00:00"})
+    hub._state_reader = reader
+
+    deadline = hub._get_deadline("input_datetime.deadline", now)
+    # Should be 06:00 CET (= 05:00 UTC), not 06:00 UTC
+    assert deadline.tzinfo is not None
+    assert deadline.astimezone(UTC).hour == 5, "06:00 CET should be 05:00 UTC"
+    assert deadline.day == 16  # next day in local time
 
 
 @pytest.mark.asyncio

--- a/tests/test_hub_freeze.py
+++ b/tests/test_hub_freeze.py
@@ -199,20 +199,94 @@ async def test_deadline_works_with_aware_now():
 
 
 @pytest.mark.asyncio
-async def test_deadline_local_timezone():
-    """Deadline 06:00 local (CET) must not become 06:00 UTC."""
+async def test_deadline_local_timezone_winter():
+    """Deadline 06:00 CET (winter, UTC+1) must be 05:00 UTC, not 06:00 UTC."""
     hub = Hub(None, [make_vehicle_config()], test=True)
     hub._local_tz = ZoneInfo("Europe/Stockholm")
-    # now = 2024-01-15 22:00 UTC = 2024-01-15 23:00 CET
+    # 2024-01-15 22:00 UTC = 23:00 CET — deadline 06:00 is tomorrow
     now = datetime(2024, 1, 15, 22, 0, tzinfo=UTC)
     reader = FakeStateReader({"input_datetime.deadline": "06:00:00"})
     hub._state_reader = reader
 
     deadline = hub._get_deadline("input_datetime.deadline", now)
-    # Should be 06:00 CET (= 05:00 UTC), not 06:00 UTC
     assert deadline.tzinfo is not None
-    assert deadline.astimezone(UTC).hour == 5, "06:00 CET should be 05:00 UTC"
-    assert deadline.day == 16  # next day in local time
+    utc_deadline = deadline.astimezone(UTC)
+    assert utc_deadline.hour == 5, "06:00 CET should be 05:00 UTC"
+    assert utc_deadline.day == 16
+
+
+@pytest.mark.asyncio
+async def test_deadline_local_timezone_summer():
+    """Deadline 06:00 CEST (summer, UTC+2) must be 04:00 UTC, not 06:00 UTC."""
+    hub = Hub(None, [make_vehicle_config()], test=True)
+    hub._local_tz = ZoneInfo("Europe/Stockholm")
+    # 2024-07-10 20:00 UTC = 22:00 CEST — deadline 06:00 is tomorrow
+    now = datetime(2024, 7, 10, 20, 0, tzinfo=UTC)
+    reader = FakeStateReader({"input_datetime.deadline": "06:00:00"})
+    hub._state_reader = reader
+
+    deadline = hub._get_deadline("input_datetime.deadline", now)
+    utc_deadline = deadline.astimezone(UTC)
+    assert utc_deadline.hour == 4, "06:00 CEST should be 04:00 UTC"
+    assert utc_deadline.day == 11
+
+
+@pytest.mark.asyncio
+async def test_deadline_across_spring_dst_transition():
+    """Now is Saturday CET, deadline Sunday morning after clocks spring forward.
+
+    2024-03-30 22:00 UTC = 23:00 CET (Saturday).
+    Clocks spring forward 2024-03-31 02:00 CET → 03:00 CEST.
+    Deadline 06:00 local on Sunday = 06:00 CEST = 04:00 UTC.
+    """
+    hub = Hub(None, [make_vehicle_config()], test=True)
+    hub._local_tz = ZoneInfo("Europe/Stockholm")
+    now = datetime(2024, 3, 30, 22, 0, tzinfo=UTC)
+    reader = FakeStateReader({"input_datetime.deadline": "06:00:00"})
+    hub._state_reader = reader
+
+    deadline = hub._get_deadline("input_datetime.deadline", now)
+    utc_deadline = deadline.astimezone(UTC)
+    assert utc_deadline.day == 31, "Deadline should be Sunday"
+    assert utc_deadline.hour == 4, "06:00 CEST = 04:00 UTC after spring forward"
+
+
+@pytest.mark.asyncio
+async def test_deadline_across_fall_dst_transition():
+    """Now is Saturday CEST, deadline Sunday morning after clocks fall back.
+
+    2024-10-26 20:00 UTC = 22:00 CEST (Saturday).
+    Clocks fall back 2024-10-27 03:00 CEST → 02:00 CET.
+    Deadline 06:00 local on Sunday = 06:00 CET = 05:00 UTC.
+    """
+    hub = Hub(None, [make_vehicle_config()], test=True)
+    hub._local_tz = ZoneInfo("Europe/Stockholm")
+    now = datetime(2024, 10, 26, 20, 0, tzinfo=UTC)
+    reader = FakeStateReader({"input_datetime.deadline": "06:00:00"})
+    hub._state_reader = reader
+
+    deadline = hub._get_deadline("input_datetime.deadline", now)
+    utc_deadline = deadline.astimezone(UTC)
+    assert utc_deadline.day == 27, "Deadline should be Sunday"
+    assert utc_deadline.hour == 5, "06:00 CET = 05:00 UTC after fall back"
+
+
+@pytest.mark.asyncio
+async def test_deadline_same_day_not_passed_local():
+    """Deadline today when it hasn't passed yet in local time.
+
+    2024-01-15 03:00 UTC = 04:00 CET.  Deadline 06:00 CET is still today.
+    """
+    hub = Hub(None, [make_vehicle_config()], test=True)
+    hub._local_tz = ZoneInfo("Europe/Stockholm")
+    now = datetime(2024, 1, 15, 3, 0, tzinfo=UTC)
+    reader = FakeStateReader({"input_datetime.deadline": "06:00:00"})
+    hub._state_reader = reader
+
+    deadline = hub._get_deadline("input_datetime.deadline", now)
+    utc_deadline = deadline.astimezone(UTC)
+    assert utc_deadline.day == 15, "Deadline should be today, not tomorrow"
+    assert utc_deadline.hour == 5, "06:00 CET = 05:00 UTC"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- **Bug:** `input_datetime` deadline values (user's local time, e.g. 06:00 CET) were applied to a UTC datetime via `replace()`, effectively shifting the deadline by the UTC offset (06:00 CET → 06:00 UTC = 07:00 CET)
- **Fix:** Convert `now` to HA's configured timezone (`hass.config.time_zone`) before replacing hour/minute in `_get_deadline()`
- Bumps version to 0.4.3

## Test plan
- [ ] New test `test_deadline_local_timezone` verifies 06:00 CET → 05:00 UTC (not 06:00 UTC)
- [ ] Existing deadline tests pass unchanged (hass=None falls back to UTC)
- [ ] Deploy to HA and verify charge periods respect the configured deadline time