### PR TITLE
fix: editable deadline_entity (and other identity fields) in options flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4.4] - 2026-04-29
+
+### Fixed
+- Options flow edit form now includes `deadline_entity`, `soc_sensor`, `battery_capacity`, and `price_sensor` so they can be changed after initial setup. Previously a wrong/blank `deadline_entity` could only be corrected by removing and re-adding the integration, and the deadline would silently fall back to `now + 8h`.
+
 ## [0.4.3] - 2026-03-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 - Options flow edit form now includes `deadline_entity`, `soc_sensor`, `battery_capacity`, and `price_sensor` so they can be changed after initial setup. Previously a wrong/blank `deadline_entity` could only be corrected by removing and re-adding the integration, and the deadline would silently fall back to `now + 8h`.
+- Required entity_id fields (vehicle name, SoC sensor, deadline, price sensor) now reject blank submissions in both the add and edit forms — prevents silently saving an empty value that triggers the same fallback.
+- `strings.json` mirrors the new edit-form keys added to `translations/en.json` so translation tooling stays in sync.
 
 ## [0.4.3] - 2026-03-27
 

--- a/custom_components/ev_charge_planner/config_flow.py
+++ b/custom_components/ev_charge_planner/config_flow.py
@@ -197,6 +197,22 @@ class EVChargePlannerOptionsFlow(config_entries.OptionsFlow):
 
         schema = vol.Schema(
             {
+                vol.Required(
+                    CONF_SOC_SENSOR,
+                    default=current.get(CONF_SOC_SENSOR, ""),
+                ): str,
+                vol.Required(
+                    CONF_BATTERY_CAPACITY,
+                    default=current.get(CONF_BATTERY_CAPACITY),
+                ): vol.Coerce(float),
+                vol.Required(
+                    CONF_DEADLINE_ENTITY,
+                    default=current.get(CONF_DEADLINE_ENTITY, ""),
+                ): str,
+                vol.Required(
+                    CONF_PRICE_SENSOR,
+                    default=current.get(CONF_PRICE_SENSOR, ""),
+                ): str,
                 vol.Optional(
                     CONF_ENABLED_ENTITY,
                     description={"suggested_value": current.get(CONF_ENABLED_ENTITY, "")},

--- a/custom_components/ev_charge_planner/config_flow.py
+++ b/custom_components/ev_charge_planner/config_flow.py
@@ -31,18 +31,21 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+NON_EMPTY_STR = vol.All(str, vol.Length(min=1))
+
+
 VEHICLE_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_VEHICLE_NAME): str,
-        vol.Required(CONF_SOC_SENSOR): str,
+        vol.Required(CONF_VEHICLE_NAME): NON_EMPTY_STR,
+        vol.Required(CONF_SOC_SENSOR): NON_EMPTY_STR,
         vol.Optional(CONF_SOC_TARGET_ENTITY): str,
         vol.Optional(CONF_SOC_TARGET_FIXED, default=DEFAULT_SOC_TARGET): vol.Coerce(float),
         vol.Required(CONF_BATTERY_CAPACITY): vol.Coerce(float),
         vol.Optional(CONF_CHARGE_POWER): vol.Coerce(float),
         vol.Optional(CONF_CHARGE_POWER_ENTITY): str,
         vol.Optional(CONF_ENABLED_ENTITY): str,
-        vol.Required(CONF_DEADLINE_ENTITY): str,
-        vol.Required(CONF_PRICE_SENSOR): str,
+        vol.Required(CONF_DEADLINE_ENTITY): NON_EMPTY_STR,
+        vol.Required(CONF_PRICE_SENSOR): NON_EMPTY_STR,
         vol.Optional(CONF_FEES_ENTITY): str,
         vol.Optional(CONF_FEES_FIXED, default=DEFAULT_FEES): vol.Coerce(float),
         vol.Optional(CONF_VAT_PERCENT, default=DEFAULT_VAT_PERCENT): vol.All(
@@ -200,7 +203,7 @@ class EVChargePlannerOptionsFlow(config_entries.OptionsFlow):
                 vol.Required(
                     CONF_SOC_SENSOR,
                     default=current.get(CONF_SOC_SENSOR, ""),
-                ): str,
+                ): NON_EMPTY_STR,
                 vol.Required(
                     CONF_BATTERY_CAPACITY,
                     default=current.get(CONF_BATTERY_CAPACITY),
@@ -208,11 +211,11 @@ class EVChargePlannerOptionsFlow(config_entries.OptionsFlow):
                 vol.Required(
                     CONF_DEADLINE_ENTITY,
                     default=current.get(CONF_DEADLINE_ENTITY, ""),
-                ): str,
+                ): NON_EMPTY_STR,
                 vol.Required(
                     CONF_PRICE_SENSOR,
                     default=current.get(CONF_PRICE_SENSOR, ""),
-                ): str,
+                ): NON_EMPTY_STR,
                 vol.Optional(
                     CONF_ENABLED_ENTITY,
                     description={"suggested_value": current.get(CONF_ENABLED_ENTITY, "")},

--- a/custom_components/ev_charge_planner/manifest.json
+++ b/custom_components/ev_charge_planner/manifest.json
@@ -5,5 +5,5 @@
     "config_flow": true,
     "after_dependencies": ["nordpool"],
     "iot_class": "calculated",
-    "version": "0.4.3"
+    "version": "0.4.4"
 }

--- a/custom_components/ev_charge_planner/strings.json
+++ b/custom_components/ev_charge_planner/strings.json
@@ -75,6 +75,10 @@
             "edit_vehicle": {
                 "title": "Edit {vehicle_name}",
                 "data": {
+                    "soc_sensor": "Current SoC sensor (entity_id)",
+                    "battery_capacity": "Battery capacity (kWh)",
+                    "deadline_entity": "Deadline (input_datetime entity_id)",
+                    "price_sensor": "Price sensor (NordPool entity_id)",
                     "enabled_entity": "Charging enabled (input_boolean entity_id)",
                     "soc_target_entity": "Target SoC sensor (entity_id)",
                     "soc_target_fixed": "Target SoC (fixed %)",

--- a/custom_components/ev_charge_planner/translations/en.json
+++ b/custom_components/ev_charge_planner/translations/en.json
@@ -75,6 +75,10 @@
             "edit_vehicle": {
                 "title": "Edit {vehicle_name}",
                 "data": {
+                    "soc_sensor": "Current SoC sensor (entity_id)",
+                    "battery_capacity": "Battery capacity (kWh)",
+                    "deadline_entity": "Deadline (input_datetime entity_id)",
+                    "price_sensor": "Price sensor (NordPool entity_id)",
                     "enabled_entity": "Charging enabled (input_boolean entity_id)",
                     "soc_target_entity": "Target SoC sensor (entity_id)",
                     "soc_target_fixed": "Target SoC (fixed %)",


### PR DESCRIPTION
## Summary
- The options-flow edit step only exposed soc/charge/fees/vat fields, so `deadline_entity`, `soc_sensor`, `battery_capacity` and `price_sensor` could not be changed after initial setup. Added them to the edit schema (with current values prefilled) and to `translations/en.json`.
- Closes the silent failure mode where a blank/stale `deadline_entity` falls back to `now + 8h` in `_get_deadline()` and is uncorrectable from the UI.
- Bumps version to `0.4.4` and adds CHANGELOG entry.

## Repro for the deadline fallback
- A vehicle whose `deadline_entity` is blank/missing produced `deadline = last_updated + 8h` (e.g. `19:01:28Z` → `03:01:28Z` next day) instead of reading `input_datetime.*` (14:30 local).

## Test plan
- [x] `python -m pytest tests/ -q` — 91 passed
- [x] `python -m black custom_components/ev_charge_planner/config_flow.py` — clean
- [ ] Install 0.4.4, open integration → Configure → edit a vehicle, confirm `deadline_entity`, `soc_sensor`, `battery_capacity`, `price_sensor` are now editable and prefilled
- [ ] Set `deadline_entity` to a valid `input_datetime` and confirm the sensor's `deadline` attribute reflects the configured local time (not `now + 8h`)